### PR TITLE
Process all of the YAML test files with Jinja2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ clean:
 	rm -rf dist build
 
 dist: clean
-	python setup.py sdist bdist_wheel
+	python3 setup.py sdist bdist_wheel
 
 release: test dist twine_check
-	python -m twine upload dist/*
+	python3 -m twine upload dist/*
 
 twine_check:
 	twine check dist/*.whl
 
 test:
-	pytest-3 -v ./test --capture=no
+	pytest -v ./test --capture=no

--- a/http_test/runner.py
+++ b/http_test/runner.py
@@ -49,7 +49,7 @@ def run_specfiles(
     for test_filename in test_files:
         test_file = Path(test_filename)
         spec_file = SpecFile(path=test_file)
-        tests = spec_file.load_tests()
+        tests = spec_file.load_tests(template_vars=template_vars)
 
         for test in tests:
             inject_test_config_dict(test, target_host, template_vars)

--- a/http_test/spec.py
+++ b/http_test/spec.py
@@ -165,7 +165,6 @@ def verify_response(result: dict, requirements: dict, template_vars: dict = None
 
             for expected_header in expected_headers:
                 header_name, expected_value = list(map(str.strip, expected_header.split(":", 1)))
-                expected_value = replace_variables(expected_value, template_vars)
                 actual_values = response_headers.get(header_name) or ""
 
                 # For multiple instances of the same HTTP header, get() returns a list
@@ -201,8 +200,8 @@ def verify_response(result: dict, requirements: dict, template_vars: dict = None
             expected_strings = requirements.get("body")
             response_body = result.get("response_body_decoded")
             for expected_string in expected_strings:
-                expected_bytes = replace_variables(expected_string, template_vars).encode("utf-8")
-                # Must be bytes vs bytes here
+                # Must compare bytes vs bytes here
+                expected_bytes = expected_string.encode("utf-8")
                 assert (
                     expected_bytes in response_body
                 ), f"Expected response body to contain '{expected_string}': {_dump(result)}"
@@ -232,10 +231,6 @@ def resolve_connect_to(url: str, test_config: dict) -> list:
     if connect_to and not isinstance(connect_to, list):
         connect_to = [connect_to]
 
-    if connect_to:
-        template_vars = test_config.get("template_vars")
-        connect_to = [replace_variables(e, template_vars) for e in connect_to]
-
     return connect_to
 
 
@@ -248,9 +243,6 @@ def url_from_spec(test_spec: dict) -> str:
     url = test_spec.get("url")
     if is_relative_url(url):
         url = base_url + url
-
-    template_vars = test_config.get("template_vars")
-    url = replace_variables(url, template_vars)
 
     return url
 
@@ -270,8 +262,6 @@ def request_from_spec(test_spec: dict, test_config: dict) -> Request:
         server: openresty
     ```
     """
-    template_vars = test_config.get("template_vars")
-
     url = url_from_spec(test_spec)
 
     # This allows one to have dynamic --connect-to settings, such as:
@@ -288,9 +278,6 @@ def request_from_spec(test_spec: dict, test_config: dict) -> Request:
     use_http2 = test_spec.get("http2", False)
     verbose_output = test_spec.get("verbose", False)
     payload = test_spec.get("payload", None)
-
-    if headers:
-        headers = [replace_variables(h, template_vars) for h in headers]
 
     if verbose_output:
         print()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ isort
 black
 pytest
 setuptools
+wheel


### PR DESCRIPTION
Process the source YAML test file with Jinja2 replacing all variables. This will also execute any jinja2 directives present in the source YAML file within comment lines.

This is useful to factor out common expressions to use those across all the spec tests in a single YAML file.

Next step will be to remove the replace_variables step for each test.