### PR TITLE
Pin websockets to ~=13.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pycurl~=7.45.2
 brotli==1.0.9
 certifi~=2023.7.22
 asyncio==3.4.3
-websockets>=11
+websockets~=13.1.0
 pyyaml
 jinja2~=3.1.2
 


### PR DESCRIPTION
version 14.0 introduces some non backward compatible changes as well as drops support for python 3.8